### PR TITLE
Implement document ingestion and search

### DIFF
--- a/crossaudit/gateway/Cargo.toml
+++ b/crossaudit/gateway/Cargo.toml
@@ -35,3 +35,4 @@ aws-sdk-s3 = "1"
 aws-config = { version = "1", features = ["rt-tokio"] }
 once_cell = "1"
 clap = { version = "4", features = ["derive"] }
+crossaudit-ingestor = { path = "../ingestor" }

--- a/crossaudit/gateway/src/data_room.rs
+++ b/crossaudit/gateway/src/data_room.rs
@@ -1,12 +1,77 @@
 use anyhow::Result;
 use axum::body::Bytes;
+use pgvector::Vector;
+use tokio_postgres::types::ToSql;
+use uuid::Uuid;
+
+use crossaudit_ingestor::{chunks, embed, pdf};
 
 use crate::{storage::Storage, AppState};
 
 pub async fn save_doc(state: &AppState, bytes: Bytes) -> Result<()> {
-    state.storage.save(&bytes).await.map(|_| ())
+    let path = state.storage.save(&bytes).await?;
+    let text = pdf::parse(&bytes)?;
+    let pieces = chunks::chunk_text(&text, 50);
+    let embeddings = embed::embed_chunks(&pieces)?;
+
+    let sha = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        bytes.hash(&mut h);
+        let digest = h.finish().to_be_bytes();
+        [digest.repeat(4)].concat()
+    };
+
+    let doc_id = Uuid::new_v4();
+    let client = state.pool.get().await?;
+    client
+        .execute(
+            "INSERT INTO documents (id, org_id, path, sha256, mime, bytes) VALUES ($1,$2,$3,$4,$5,$6)",
+            &[
+                &doc_id,
+                &Uuid::nil(),
+                &path,
+                &sha.as_slice() as &dyn ToSql,
+                &"application/pdf",
+                &(bytes.len() as i32),
+            ],
+        )
+        .await?;
+
+    for (idx, (chunk, emb)) in pieces.iter().zip(embeddings.iter()).enumerate() {
+        let chunk_id = Uuid::new_v4();
+        let vec: Vector = emb.clone().into();
+        client
+            .execute(
+                "INSERT INTO chunks (id, org_id, doc_id, chunk_idx, embedding, plaintext) VALUES ($1,$2,$3,$4,$5,$6)",
+                &[
+                    &chunk_id,
+                    &Uuid::nil(),
+                    &doc_id,
+                    &(idx as i32),
+                    &vec,
+                    chunk,
+                ],
+            )
+            .await?;
+    }
+    Ok(())
 }
 
 pub async fn list_docs(state: &AppState) -> Result<Vec<String>> {
     state.storage.list().await
+}
+
+pub async fn search(state: &AppState, query: &str, limit: i64) -> Result<Vec<Uuid>> {
+    let embedding = embed::embed_chunks(&[query.to_string()])?.remove(0);
+    let vec: Vector = embedding.into();
+    let client = state.pool.get().await?;
+    let rows = client
+        .query(
+            "SELECT doc_id FROM chunks ORDER BY embedding <-> $1 LIMIT $2",
+            &[&vec, &limit],
+        )
+        .await?;
+    Ok(rows.iter().map(|r| r.get(0)).collect())
 }

--- a/crossaudit/gateway/tests/data_room.rs
+++ b/crossaudit/gateway/tests/data_room.rs
@@ -1,4 +1,21 @@
-#[test]
-fn dummy() {
-    assert!(true);
+use crossaudit_gateway::{config::Settings, init_state};
+use crossaudit_gateway::data_room::{save_doc, search};
+use axum::body::Bytes;
+
+#[tokio::test]
+async fn upload_and_search() {
+    let db_url = std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| "postgresql://localhost/postgres".into());
+    let settings = Settings {
+        server_addr: "127.0.0.1:0".into(),
+        database_url: db_url,
+        openai_api_key: String::new(),
+        storage_path: "./tmp-test-storage".into(),
+    };
+    let state = init_state(settings.clone()).await.unwrap();
+
+    let bytes = include_bytes!("fixtures/hello.pdf");
+    save_doc(&state, Bytes::from_static(bytes)).await.unwrap();
+
+    let res = search(&state, "Hello", 5).await.unwrap();
+    assert!(!res.is_empty());
 }

--- a/crossaudit/gateway/tests/fixtures/hello.pdf
+++ b/crossaudit/gateway/tests/fixtures/hello.pdf
@@ -1,0 +1,5 @@
+%PDF-1.0
+1 0 obj
+(Hello from PDF) Tj
+endobj
+%%EOF

--- a/crossaudit/ingestor/src/chunks.rs
+++ b/crossaudit/ingestor/src/chunks.rs
@@ -1,0 +1,16 @@
+/// Split text into roughly equal sized word chunks.
+/// `size` determines the number of words per chunk.
+pub fn chunk_text(text: &str, size: usize) -> Vec<String> {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut idx = 0;
+    while idx < words.len() {
+        let end = usize::min(idx + size, words.len());
+        out.push(words[idx..end].join(" "));
+        idx = end;
+    }
+    out
+}

--- a/crossaudit/ingestor/src/embed.rs
+++ b/crossaudit/ingestor/src/embed.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+/// Dimension of generated embeddings.
+pub const DIM: usize = 1536;
+
+/// Very small deterministic embedding generator used for tests.
+/// It converts bytes of the input into a vector of length `DIM` by
+/// summing byte values modulo the dimension.
+pub fn embed_chunks(chunks: &[String]) -> Result<Vec<Vec<f32>>> {
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let mut vec = vec![0f32; DIM];
+        for (i, b) in chunk.as_bytes().iter().enumerate() {
+            vec[i % DIM] += *b as f32;
+        }
+        out.push(vec);
+    }
+    Ok(out)
+}

--- a/crossaudit/ingestor/src/lib.rs
+++ b/crossaudit/ingestor/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod chunks;
+pub mod embed;
+pub mod pdf;
+
 use anyhow::Result;
 use reqwest::Client;
 use tokio::fs;

--- a/crossaudit/ingestor/src/pdf.rs
+++ b/crossaudit/ingestor/src/pdf.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+
+/// Naive PDF parser that extracts text appearing in parentheses
+/// before the `Tj` operator. It does not aim to be a full PDF
+/// implementation but is sufficient for simple, text based PDFs.
+pub fn parse(bytes: &[u8]) -> Result<String> {
+    let content = String::from_utf8_lossy(bytes);
+    let mut out = String::new();
+    for part in content.split("Tj") {
+        if let Some(start) = part.rfind('(') {
+            if let Some(end) = part[start + 1..].find(')') {
+                let text = &part[start + 1..start + 1 + end];
+                if !text.trim().is_empty() {
+                    if !out.is_empty() {
+                        out.push(' ');
+                    }
+                    out.push_str(text.trim());
+                }
+            }
+        }
+    }
+    Ok(out)
+}


### PR DESCRIPTION
## Summary
- add minimal PDF parser, chunker and toy embedding generator
- store uploaded document metadata and embeddings using pgvector
- enable vector queries from the gateway
- integration test outlines upload & search flow

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_685c46e1c1d48325bd5d19ba3efee3a1