### PR TITLE
Implement policy enforcement with SSE alerts

### DIFF
--- a/crossaudit/gateway/Cargo.toml
+++ b/crossaudit/gateway/Cargo.toml
@@ -35,3 +35,4 @@ aws-sdk-s3 = "1"
 aws-config = { version = "1", features = ["rt-tokio"] }
 once_cell = "1"
 clap = { version = "4", features = ["derive"] }
+tokio-stream = "0.1"

--- a/crossaudit/gateway/src/lib.rs
+++ b/crossaudit/gateway/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::{config::Settings, policy::PolicyEngine, storage::Storage};
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
 use tokio_postgres::{NoTls, Config as PgConfig};
+use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -8,6 +9,7 @@ pub struct AppState {
     pub pool: Pool,
     pub policy: PolicyEngine,
     pub storage: Storage,
+    pub alerts: broadcast::Sender<String>,
 }
 
 pub async fn init_state(settings: Settings) -> anyhow::Result<AppState> {
@@ -18,14 +20,16 @@ pub async fn init_state(settings: Settings) -> anyhow::Result<AppState> {
 
     let policy = PolicyEngine::load_default()?;
     let storage = Storage::new(&settings.storage_path).await?;
+    let (tx, _rx) = broadcast::channel(100);
 
-    Ok(AppState { settings, pool, policy, storage })
+    Ok(AppState { settings, pool, policy, storage, alerts: tx })
 }
 
 pub fn build_router(state: AppState) -> axum::Router {
     use axum::routing::{get, post};
     axum::Router::new()
         .route("/chat", post(crate::routes::chat))
+        .route("/alerts", get(crate::routes::alerts))
         .route("/docs", get(crate::routes::list_docs))
         .route("/upload", post(crate::routes::upload_doc))
         .with_state(state)

--- a/crossaudit/gateway/src/routes.rs
+++ b/crossaudit/gateway/src/routes.rs
@@ -1,7 +1,10 @@
-use axum::{extract::State, response::IntoResponse, Json};
+use axum::{extract::State, response::{IntoResponse, sse::{Event, Sse, KeepAlive}}, Json};
+use futures_util::{StreamExt, stream::Stream};
+use tokio_stream::wrappers::BroadcastStream;
 use serde::{Deserialize, Serialize};
-
-use crate::{data_room, llm_client, AppState};
+use crate::{data_room, llm_client, audit, AppState};
+use axum::http::StatusCode;
+use std::convert::Infallible;
 
 #[derive(Deserialize)]
 pub struct ChatRequest {
@@ -14,9 +17,23 @@ pub struct ChatResponse {
 }
 
 pub async fn chat(State(state): State<AppState>, Json(body): Json<ChatRequest>) -> impl IntoResponse {
-    match llm_client::chat(&state, &body.prompt).await {
-        Ok(resp) => Json(ChatResponse { response: resp }).into_response(),
-        Err(err) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+    let (modified, action) = state.policy.apply(&body.prompt);
+    if matches!(action.as_deref(), Some("block")) {
+        let _ = audit::log_chat(&state, "00000000-0000-0000-0000-000000000000", &body.prompt, "", "block", 0).await;
+        let _ = state.alerts.send(format!("blocked:{}", body.prompt));
+        return (StatusCode::FORBIDDEN, "blocked").into_response();
+    }
+
+    let prompt = if matches!(action.as_deref(), Some("rewrite")) { modified } else { body.prompt.clone() };
+
+    match llm_client::chat(&state, &prompt).await {
+        Ok(resp) => {
+            let tokens = resp.split_whitespace().count() as i32;
+            let act = action.as_deref().unwrap_or("allow");
+            let _ = audit::log_chat(&state, "00000000-0000-0000-0000-000000000000", &body.prompt, &resp, act, tokens).await;
+            Json(ChatResponse { response: resp }).into_response()
+        }
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     }
 }
 
@@ -32,4 +49,12 @@ pub async fn upload_doc(State(state): State<AppState>, bytes: axum::body::Bytes)
         Ok(()) => axum::http::StatusCode::CREATED.into_response(),
         Err(err) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     }
+}
+
+pub async fn alerts(State(state): State<AppState>) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.alerts.subscribe();
+    let stream = BroadcastStream::new(rx)
+        .filter_map(|msg| async move { msg.ok() })
+        .map(|msg| Ok(Event::default().data(msg)));
+    Sse::new(stream).keep_alive(KeepAlive::default())
 }

--- a/crossaudit/gateway/tests/data_room.rs
+++ b/crossaudit/gateway/tests/data_room.rs
@@ -1,4 +1,8 @@
+use crossaudit_gateway::policy::PolicyEngine;
+
 #[test]
-fn dummy() {
-    assert!(true);
+fn block_applied() {
+    let policy = PolicyEngine::load_from_path("../config/rules.yaml").unwrap();
+    let (_, action) = policy.apply("what the fuck");
+    assert_eq!(action.unwrap(), "block");
 }

--- a/crossaudit/gateway/tests/e2e.rs
+++ b/crossaudit/gateway/tests/e2e.rs
@@ -1,4 +1,0 @@
-#[test]
-fn dummy() {
-    assert!(true);
-}

--- a/crossaudit/gateway/tests/e2e_rewrite.rs
+++ b/crossaudit/gateway/tests/e2e_rewrite.rs
@@ -1,4 +1,9 @@
+use crossaudit_gateway::policy::PolicyEngine;
+
 #[test]
-fn dummy() {
-    assert!(true);
+fn rewrite_applied() {
+    let policy = PolicyEngine::load_from_path("../config/rules.yaml").unwrap();
+    let (out, action) = policy.apply("my ssn is 123-45-6789");
+    assert_eq!(out, "my ssn is ***-**-****");
+    assert_eq!(action.unwrap(), "rewrite");
 }


### PR DESCRIPTION
## Summary
- enforce regex policy in `/chat` with block/rewrite logic
- persist decisions using `audit::log_chat`
- broadcast block events via new SSE alerts endpoint
- wire alerts in `AppState` and router
- test policy block and rewrite behaviour

## Testing
- `cargo test --quiet` *(fails: couldn't fetch index)*

------
https://chatgpt.com/codex/tasks/task_e_685c46e3a5dc83258ffeab5d2b55c081