### PR TITLE
Improve CrossAudit web UI

### DIFF
--- a/crossaudit/gateway/Cargo.toml
+++ b/crossaudit/gateway/Cargo.toml
@@ -35,10 +35,7 @@ aws-sdk-s3 = "1"
 aws-config = { version = "1", features = ["rt-tokio"] }
 once_cell = "1"
 clap = { version = "4", features = ["derive"] }
-<<<<<<< codex/replace-dummy-unit-tests-and-update-docs
+crossaudit-ingestor = { path = "../ingestor" }
 
 [dev-dependencies]
 tempfile = "3"
-=======
-crossaudit-ingestor = { path = "../ingestor" }
->>>>>>> main

--- a/crossaudit/web/src/app/app/admin/billing/page.tsx
+++ b/crossaudit/web/src/app/app/admin/billing/page.tsx
@@ -1,1 +1,15 @@
-export default function Billing() { return <div>Billing</div>; }
+"use client";
+
+export default function Billing() {
+  async function startSession() {
+    await fetch('/api/org/billing-session');
+    alert('Billing session started');
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Billing</h2>
+      <button onClick={startSession}>Start Session</button>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/admin/members/page.tsx
+++ b/crossaudit/web/src/app/app/admin/members/page.tsx
@@ -1,1 +1,21 @@
-export default function Members() { return <div>Members</div>; }
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function Members() {
+  const [members, setMembers] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch('/api/org/members').then(r => r.json()).then(setMembers);
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Members</h2>
+      <ul className="list-disc ml-6">
+        {members.map((m, i) => (
+          <li key={i}>{JSON.stringify(m)}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/admin/policy/page.tsx
+++ b/crossaudit/web/src/app/app/admin/policy/page.tsx
@@ -1,1 +1,39 @@
-export default function Policy() { return <div>Policy</div>; }
+"use client";
+import { useState } from 'react';
+
+export default function Policy() {
+  const [policy, setPolicy] = useState('');
+
+  async function validate() {
+    await fetch('/api/policy/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ policy }),
+    });
+    alert('Policy validated');
+  }
+
+  async function save() {
+    await fetch('/api/policy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ policy }),
+    });
+    alert('Policy saved');
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Policy</h2>
+      <textarea
+        className="w-full border p-2"
+        value={policy}
+        onChange={e => setPolicy(e.target.value)}
+      />
+      <div className="mt-2 space-x-2">
+        <button onClick={validate}>Validate</button>
+        <button onClick={save}>Save</button>
+      </div>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/admin/settings/page.tsx
+++ b/crossaudit/web/src/app/app/admin/settings/page.tsx
@@ -1,1 +1,27 @@
-export default function Settings() { return <div>Settings</div>; }
+"use client";
+import { useState } from 'react';
+
+export default function Settings() {
+  const [url, setUrl] = useState('');
+
+  async function save() {
+    await fetch('/api/org/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    alert('Webhook updated');
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Webhook URL</h2>
+      <input
+        className="border p-1"
+        value={url}
+        onChange={e => setUrl(e.target.value)}
+      />
+      <button className="ml-2" onClick={save}>Save</button>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/data-room/page.tsx
+++ b/crossaudit/web/src/app/app/data-room/page.tsx
@@ -1,1 +1,32 @@
-export default function DataRoom() { return <div>Data Room</div>; }
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function DataRoom() {
+  const [docs, setDocs] = useState<string[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    fetch('/api/docs').then(r => r.json()).then(setDocs);
+  }, []);
+
+  async function upload() {
+    if (!file) return;
+    const buf = await file.arrayBuffer();
+    await fetch('/api/upload', { method: 'POST', body: buf });
+    const d = await fetch('/api/docs').then(r => r.json());
+    setDocs(d);
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Documents</h2>
+      <ul className="list-disc ml-6 mb-4">
+        {docs.map(d => (
+          <li key={d}>{d}</li>
+        ))}
+      </ul>
+      <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+      <button className="ml-2" onClick={upload}>Upload</button>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/layout.tsx
+++ b/crossaudit/web/src/app/app/layout.tsx
@@ -1,3 +1,19 @@
+"use client";
+import Link from 'next/link';
+import { useAuth } from '../../lib/auth';
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  return <div>{children}</div>;
+  const { user } = useAuth();
+  return (
+    <div>
+      <nav className="space-x-4 p-2 border-b">
+        <Link href="/app">Chat</Link>
+        <Link href="/app/data-room">Data Room</Link>
+        <Link href="/app/logs">Logs</Link>
+        <Link href="/app/admin/members">Admin</Link>
+        <span className="float-right">{user}</span>
+      </nav>
+      <main className="p-4">{children}</main>
+    </div>
+  );
 }

--- a/crossaudit/web/src/app/app/logs/page.tsx
+++ b/crossaudit/web/src/app/app/logs/page.tsx
@@ -1,1 +1,19 @@
-export default function Logs() { return <div>Logs</div>; }
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function Logs() {
+  const [logs, setLogs] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch('/api/logs').then(r => r.json()).then(setLogs);
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Audit Log</h2>
+      <pre className="whitespace-pre-wrap">
+        {JSON.stringify(logs, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/crossaudit/web/src/app/app/page.tsx
+++ b/crossaudit/web/src/app/app/page.tsx
@@ -16,9 +16,13 @@ export default function Chat() {
 
   return (
     <div>
-      <textarea value={prompt} onChange={e => setPrompt(e.target.value)} />
-      <button onClick={send}>Send</button>
-      <pre>{resp}</pre>
+      <textarea
+        className="w-full border p-2"
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+      />
+      <button className="mt-2" onClick={send}>Send</button>
+      <pre className="mt-4 whitespace-pre-wrap">{resp}</pre>
     </div>
   );
 }

--- a/crossaudit/web/src/app/layout.tsx
+++ b/crossaudit/web/src/app/layout.tsx
@@ -1,8 +1,11 @@
+"use client";
 import Toast from '../components/Toast';
 import { useState } from 'react';
+import { useAlerts } from '../lib/useAlerts';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const [msg, setMsg] = useState('');
+  useAlerts(setMsg);
   return (
     <html>
       <body>

--- a/crossaudit/web/src/app/page.tsx
+++ b/crossaudit/web/src/app/page.tsx
@@ -1,1 +1,10 @@
-export default function Page() { return <div>Landing</div>; }
+import Link from 'next/link';
+
+export default function Page() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Welcome to CrossAudit</h1>
+      <Link href="/app" className="underline text-blue-600">Enter App</Link>
+    </div>
+  );
+}

--- a/crossaudit/web/tailwind.config.js
+++ b/crossaudit/web/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: [],
+  content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- integrate `useAlerts` in root layout
- add navigation and auth info to app layout
- implement working pages for chat, data room, logs and admin section
- fix merge conflict in gateway's Cargo manifest
- configure Tailwind content paths

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685c5582d69c8325828e1681dfb6e4ad